### PR TITLE
v0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsge-language-switcher",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "author": "Erik",
   "license": "GPL-2.0-or-later",
   "main": "build/vsge-language-switcher.js",

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ By applying these classes, you can control the visibility of elements on your we
 --- 
 
 **Contact Form 7 localization:**
-In addition, this plugin adds a ‘region’ field to contact forms 7 modules.
+In addition, this plugin adds a ‘_region’ field to all the contact forms 7 modules that are wrapped with the class "localized-form".
 
 **Contributing:**
 Feel free to contribute to the development of Language Switcher. Fork the repository, make your changes, and submit a pull request.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,8 @@ export const VLS_CLASSNAME: string = 'wp-block-vsge-language-switcher';
 /** the language switcher domain (eg. vsge) */
 export const VLS_DOMAIN: string = window.languageSwitcher?.namespace || 'vsge';
 
+export const FALLBACK_REGION = 'europe';
+
 /** The allowed regions for the language switcher (eu) */
 export const VSG_ALLOWED_REGIONS: Record<
 	string,

--- a/src/frontend.ts
+++ b/src/frontend.ts
@@ -3,7 +3,7 @@ import './scss/style.scss';
 import { vls } from './frontendScripts/language-switcher';
 import { getCookieValue, hideClassesByRegion } from './frontendScripts/region-selector';
 import { appendCF7Afield } from './frontendScripts/wpcf7';
-import { VLS_DOMAIN } from './constants';
+import { FALLBACK_REGION, VLS_DOMAIN } from './constants';
 
 /**
  * The modulrRegionalController function modifies the behavior of a web page based on the user's
@@ -11,10 +11,19 @@ import { VLS_DOMAIN } from './constants';
  */
 export function vsgeRegionalController() {
 	// get the current region from the cookie
-	const region = getCookieValue( VLS_DOMAIN + '_region' );
+	let region: string | undefined = getCookieValue( VLS_DOMAIN + '_region' );
 
 	/** the language switcher */
 	document.addEventListener( 'DOMContentLoaded', vls );
+
+	if ( ! region ) {
+		const language = getCookieValue( 'pll_language' ) ?? '';
+		/** if the language is French or German, we can safety assume that the region is the same, but this is not true for the English language */
+		if ( [ 'de', 'fr' ].includes( language ) ) {
+			region = language.toLowerCase();
+		}
+		region = FALLBACK_REGION;
+	}
 
 	// hide the regions html elements based on the current region
 	hideClassesByRegion( region );

--- a/src/frontendScripts/region-selector.ts
+++ b/src/frontendScripts/region-selector.ts
@@ -8,7 +8,7 @@ import { VSG_ALLOWED_REGIONS } from '../constants';
  *             want to retrieve.
  */
 export const getCookieValue = ( name: string ) =>
-	document.cookie.match( '(^|;)\\s*' + name + '\\s*=\\s*([^;]+)' )?.pop() || '';
+	document.cookie.match( '(^|;)\\s*' + name + '\\s*=\\s*([^;]+)' )?.pop() ?? undefined;
 
 /**
  * The function generates a string of CSS class selectors to hide regions based on a given region and a
@@ -53,6 +53,29 @@ function generateRegionClassesToHide(
 }
 
 /**
+ * getRegionDefinition
+ *
+ * @param region            the current region
+ * @param regionsAllowed the current region definition, if the region is a value in the object, it will return the value, if the region is a key in the object, it will return the object.
+ * @example ```javascript
+ * getRegionDefinition('de', VSG_ALLOWED_REGIONS) // returns 'europe-de'
+ * getRegionDefinition('europe', VSG_ALLOWED_REGIONS) // returns 'europe-europe'
+ * ```
+ */
+function getRegionDefinition( region: string, regionsAllowed: Record<string, string | { [p: string]: string }> ) {
+	for ( const [ key, value ] of Object.entries( regionsAllowed ) ) {
+		if ( typeof value === 'object' ) {
+			if ( region in value ) {
+				return key + '-' + region;
+			}
+		}
+	}
+	if ( region in regionsAllowed ) {
+		return region;
+	}
+}
+
+/**
  * The function "hideClassesByRegion" hides HTML elements based on the specified region.
  *
  * @param region - The "region" parameter is a string that represents the region for which classes
@@ -65,13 +88,15 @@ export function hideClassesByRegion( region: string ) {
 		VSG_ALLOWED_REGIONS
 	);
 
+	const definition = getRegionDefinition( region, VSG_ALLOWED_REGIONS );
+
 	// hide the regions that aren't needed
 	const elementsToHide: NodeListOf<HTMLElement> =
-		document.querySelectorAll( classesToHide );
+		document.querySelectorAll( classesToHide.join() );
 
 	elementsToHide.forEach( ( element ) => {
 		// check if the element has the "show-in--region" class, this will allow multiple classes for the same element
-		if ( element.classList.contains( 'show-in--' + region ) ) {
+		if ( element.classList.contains( 'show-in--' + definition ) ) {
 			return;
 		}
 		element.style.display = 'none';

--- a/src/frontendScripts/wpcf7.ts
+++ b/src/frontendScripts/wpcf7.ts
@@ -16,7 +16,7 @@ const createFormHiddenField = (
 ): HTMLElement => {
 	const e = document.createElement( 'input' );
 	e.setAttribute( 'type', 'hidden' );
-	e.setAttribute( 'name', '_' + prefix + key );
+	e.setAttribute( 'name', `_${ prefix }_${ key }` );
 	e.setAttribute(
 		'value',
 		typeof value === 'string' ? value : JSON.stringify( value )
@@ -42,7 +42,7 @@ export function appendCF7Afield( region: string ) {
 
 			if ( hiddenInputsContainer ) {
 				hiddenInputsContainer.append(
-					createFormHiddenField( '_region', region )
+					createFormHiddenField( 'region', region )
 				);
 			}
 		}

--- a/vsge-language-switcher.php
+++ b/vsge-language-switcher.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       VSGE Language Switcher
  * Description:       A Plugin that provides the language switcher block for polylang
- * Version:           0.4.1
+ * Version:           0.4.2
  * Requires at least: 5.8
  * Tested up to:      6.5
  * Requires PHP:      7.1.0


### PR DESCRIPTION
- fix for multiple classes to hide the chosen content 

A new function was added - getRegionDefinition - will generate the right class name for countries and continents (continent or continent-country)